### PR TITLE
xss対策と文字数制限を追加

### DIFF
--- a/src/html/css/main.css
+++ b/src/html/css/main.css
@@ -47,3 +47,11 @@ body {
     flex-direction: column;
     gap: 16px;
 }
+
+.home__note {
+    color: #3cb371;
+}
+
+.home__error {
+    color: #ff4500;
+}

--- a/src/html/home/index.php
+++ b/src/html/home/index.php
@@ -1,15 +1,35 @@
 <?php
 
+const MESSAGE_MAX_LENGTH = 14;
+
 session_start();
 
 // 投稿送信時の処理
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // CSRF対策
     if (!isset($_POST['token']) || $_POST['token'] !== $_SESSION['token']) {
-        echo '不正なアクセスです';
+        $_SESSION['error'] = '不正なアクセスです！';
+        header('Location: /home');
         exit();
     }
     unset($_SESSION['token']);
-    $_SESSION['note'] = '投稿が完了しました！ ユーザーID: ' . $_POST['user_id'] . ', 投稿内容: ' . $_POST['message'];
+
+    // XSS対策
+    $sanitizedData = [];
+    foreach ($_POST as $key => $value) {
+        $sanitizedData[$key] = htmlspecialchars($value, ENT_QUOTES);
+    }
+
+    // 文字数制限
+    if (mb_strlen($sanitizedData['message']) > MESSAGE_MAX_LENGTH) {
+        $_SESSION['error'] = '文字数の上限を超えています！';
+        header('Location: /home');
+        exit();
+    }
+
+    // TODO ここでDB保存処理
+
+    $_SESSION['note'] = '投稿が完了しました！ ユーザーID: ' . '1' . ', 投稿内容: ' . $sanitizedData['message']; // FIXME valueをセッションから取得したユーザーIDに変更
     header('Location: /home');
     exit();
 }
@@ -19,8 +39,12 @@ $token = bin2hex(random_bytes(32));
 $_SESSION['token'] = $token;
 
 // 投稿完了メッセージ
-$message = $_SESSION['note'];
+$note = $_SESSION['note'];
 unset($_SESSION['note']);
+
+// エラーメッセージ
+$error = $_SESSION['error'];
+unset($_SESSION['error']);
 
 require('/var/www/app/pages/Layouts.php');
 require('/var/www/app/pages/Components.php');
@@ -28,16 +52,19 @@ require('/var/www/app/pages/Components.php');
 /** View */
 
 layoutStart('トップ | ひとこと掲示板', 'ひとこと掲示板');
-if (!is_null($message)) :
+if (!is_null($note)) :
 ?>
-    <p><?= $message ?></p>
+    <p class="home__note"><?= $note ?></p>
+<?php
+elseif (!is_null($error)) :
+?>
+    <p class="home__error"><?= $error ?></p>
 <?php
 endif;
 ?>
 <p>OOさん、メッセージをどうぞ</p>
 <form action="" method="POST" class="home__form">
     <input type="hidden" name="token" value="<?= $token ?>">
-    <input type="hidden" name="user_id" value="1"> <!-- FIXME valueをセッションから取得したユーザーIDに変更 -->
     <?php
     cTextarea('message');
     cMainButton('投稿');

--- a/src/html/home/index.php
+++ b/src/html/home/index.php
@@ -1,6 +1,6 @@
 <?php
 
-const MESSAGE_MAX_LENGTH = 14;
+const MESSAGE_MAX_LENGTH = 140;
 
 session_start();
 


### PR DESCRIPTION
## やったこと
- ユーザーIDをPOSTで送信するのは良くないらしいのでそこのinputタグは消した。(ログイン機能できたらsessionからユーザーIDを取得する予定)
- XSS対策を追加
- 文字数制限を追加
- errorメッセージを追加
- noteとerrorの文字色をつけた

# 証跡
- XSS対策効いてます
<img width="1800" alt="スクリーンショット 2022-08-27 17 23 17" src="https://user-images.githubusercontent.com/59753159/187021935-21b86bb1-739b-44fa-993f-5d5edc21393b.png">
<img width="1800" alt="スクリーンショット 2022-08-27 17 23 30" src="https://user-images.githubusercontent.com/59753159/187021938-2e88dc52-80ea-475a-b4cb-78355207e899.png">



- 文字数制限が効いています
<img width="1800" alt="スクリーンショット 2022-08-27 17 12 37" src="https://user-images.githubusercontent.com/59753159/187021787-5571ce94-0bb1-4b99-9189-dde0a9fe1a00.png">

- ちゃんと送信できます
<img width="1800" alt="スクリーンショット 2022-08-27 17 12 54" src="https://user-images.githubusercontent.com/59753159/187021969-da63233b-4025-4feb-b61b-c289c7c197e6.png">
